### PR TITLE
add delegation_set_id variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+*.tfstate

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
-resource "aws_route53_delegation_set" "delegation_set" {
-  count = var.use_delegation_set ? 1 : 0
+locals {
+  manage_delegation_set = var.manage_delegation_set && var.delegation_set_id == ""
+  delegation_set_id = (var.delegation_set_id != "") ? var.delegation_set_id : (var.manage_delegation_set ? aws_route53_delegation_set.delegation_set[0].id : "")
 }
 
-locals {
-  delegation_set_id = var.use_delegation_set ? aws_route53_delegation_set.delegation_set[0].id : ""
+resource "aws_route53_delegation_set" "delegation_set" {
+  count = local.manage_delegation_set ? 1 : 0
 }
 
 resource "aws_route53_zone" "zone" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "name_servers" {
-  value = var.use_delegation_set ? aws_route53_delegation_set.delegation_set[0].name_servers : ["Reusable delegation set disabled for this module. See module.name_of_module.zone or AWS console for NS records."]
+  value = var.manage_delegation_set ? aws_route53_delegation_set.delegation_set[0].name_servers : ["Reusable delegation set disabled for this module. See module.name_of_module.zone or AWS console for NS records."]
 }
 
 output "zone" { value = aws_route53_zone.zone }
@@ -7,3 +7,4 @@ output "a" { value = aws_route53_record.a }
 output "mx" { value = aws_route53_record.mx }
 output "txt" { value = aws_route53_record.txt }
 output "cname" { value = aws_route53_record.cname }
+output "delegation_set_id" { value = local.delegation_set_id }

--- a/variables.tf
+++ b/variables.tf
@@ -33,10 +33,16 @@ variable "ns_records" {
   default     = {}
 }
 
-variable "use_delegation_set" {
-  description = "Turn off to create/maintain a zone using randomized DNS servers. Mainly useful if you are importing an existing route53 zone, and you don't want it re-created with new primary DNS hosts."
+variable "manage_delegation_set" {
+  description = "Set to false to create/maintain a zone using randomized DNS servers. Mainly useful if you are importing an existing route53 zone, and you don't want it re-created with new primary DNS hosts. Ignored if delegation_set_id is set."
   type        = bool
   default     = true
+}
+
+variable "delegation_set_id" {
+  description = "Use this delegation set. Useful if you are using multiple copies of this module and they need to share a delegation set. Causes manage_delegation_set to be ignored."
+  type        = string
+  default     = ""
 }
 
 variable "allow_overwrite" {


### PR DESCRIPTION
- add delegation_set_id var, so we can share a delegation set across module instances
- renamed use_delegation_set to manage_delegation_set for clarity
- add delegation_set_id to output so we can get the id out of an existing instance to make more instances w/ the same NS