### PR TITLE
add *_ttl variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "a" {
   type            = "A"
   name            = each.value.name
   records         = each.value.targets
-  ttl             = 300 # ttls correspond to defaults in AWS console
+  ttl             = var.a_ttl
   allow_overwrite = var.allow_overwrite
 }
 
@@ -29,7 +29,7 @@ resource "aws_route53_record" "mx" {
   type            = "MX"
   name            = each.value.name
   records         = each.value.targets
-  ttl             = 86400
+  ttl             = var.mx_ttl
   allow_overwrite = var.allow_overwrite
 }
 
@@ -39,7 +39,7 @@ resource "aws_route53_record" "txt" {
   type            = "TXT"
   name            = each.value.name
   records         = each.value.targets
-  ttl             = 300
+  ttl             = var.txt_ttl
   allow_overwrite = var.allow_overwrite
 }
 
@@ -49,7 +49,7 @@ resource "aws_route53_record" "cname" {
   type            = "CNAME"
   name            = each.value.name
   records         = each.value.targets
-  ttl             = 300
+  ttl             = var.cname_ttl
   allow_overwrite = var.allow_overwrite
 }
 
@@ -59,6 +59,6 @@ resource "aws_route53_record" "ns" {
   type            = "NS"
   name            = each.value.name
   records         = each.value.targets
-  ttl             = 300
+  ttl             = var.ns_ttl
   allow_overwrite = var.allow_overwrite
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,33 @@ variable "allow_overwrite" {
   type        = bool
   default     = false
 }
+
+variable "a_ttl" {
+  description = "TTL for A records"
+  type        = number
+  default     = 300 # default TTL from AWS console
+}
+
+variable "mx_ttl" {
+  description = "TTL for MX records"
+  type        = number
+  default     = 86400 # default TTL from AWS console
+}
+
+variable "txt_ttl" {
+  description = "TTL for TXT records"
+  type        = number
+  default     = 300 # default TTL from AWS console
+}
+
+variable "cname_ttl" {
+  description = "TTL for CNAME records"
+  type        = number
+  default     = 300 # default TTL from AWS console
+}
+
+variable "ns_ttl" {
+  description = "TTL for NS records, does not apply to delegation set"
+  type        = number
+  default     = 300 # very short, only likely to be used while moving between DNS providers
+}


### PR DESCRIPTION
Allows setting TTL for every record of a type for the whole module.